### PR TITLE
You can create multiple client addresses/emails/phone numbers in a single API call 

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,6 +4,11 @@ RELEASE INFORMATION
 ---------------
 Ticket Evolution Framework for PHP.
 
+Aug 30, 2011 Part Deux
+- Corrected some documentation. You can create multiple client addresses/emails/phone numbers
+  in a single API call
+- Corrected demo app to show example of creating two client addresses at once
+
 Aug 30, 2011
 This is the big update you've been waiting for.
 - Added new API features through v8 including client and order methods

--- a/demo/index.php
+++ b/demo/index.php
@@ -483,20 +483,17 @@ if(isset($_GET['apiMethod'])) {
                             $address1->country_code = 'US';
                             $address1->label = 'Work';
                             
-                            /**
-                             * Create another properly formatted client address
-                             * NOT CURRENTLY SUPPORTED
+                            // Create another properly formatted client address
                             $address2 = new stdClass;
                             $address2->street_address = '744 Evergreen Terrace';
                             $address2->locality = 'Springfield';
                             $address2->region = 'MG';
                             $address2->postal_code = '58008-1111';
                             $address2->country_code = 'US';
-                            $address2->label = 'Billing (Flander’s Residence)';
-                            */
+                            $address2->label = 'Ned’s House';
                             
                             $addresses[] = $address1;
-                            //$addresses[] = $address2;
+                            $addresses[] = $address2;
                             
                             // Display the code
                             echo '$address1 = new stdClass;' . PHP_EOL
@@ -508,19 +505,17 @@ if(isset($_GET['apiMethod'])) {
                                . '$address1->country_code = \'US\';' . PHP_EOL
                                . '$address1->label = \'Work\';' . PHP_EOL
                                . PHP_EOL
-/**
+
                                . '$address2 = new stdClass;' . PHP_EOL
                                . '$address2->street_address = \'744 Evergreen Terrace\';' . PHP_EOL
                                . '$address2->locality = \'Springfield\';' . PHP_EOL
                                . '$address2->region = \'MG\';' . PHP_EOL
                                . '$address2->postal_code = \'58008-0000\';' . PHP_EOL
                                . '$address2->country_code = \'US\';' . PHP_EOL
-                               . '$address2->label = \'Billing (Flander’s Residence)\';' . PHP_EOL
+                               . '$address2->label = \'Ned’s House\';' . PHP_EOL
                                . PHP_EOL
-
- */
                                . '$addresses[] = $address1;' . PHP_EOL
-                               //. '$addresses[] = $address2;' . PHP_EOL
+                               . '$addresses[] = $address2;' . PHP_EOL
                                . PHP_EOL
                                . '$results = $tevo->' . $apiMethod . '($clientId, $addresses);' . PHP_EOL
                             ;

--- a/library/Ticketevolution/Webservice.php
+++ b/library/Ticketevolution/Webservice.php
@@ -549,7 +549,6 @@ class TicketEvolution_Webservice
 
     /**
      * Create a client address
-     * Currently the API only supports making one at a time
      *
      * @param  int $clientId ID of the specific client
      * @param  array $addresses Array of address data structured per API example
@@ -707,7 +706,6 @@ class TicketEvolution_Webservice
 
     /**
      * Create a client phone number
-     * Currently the API only supports making one at a time
      *
      * @param  int $clientId ID of the specific client
      * @param  array $phoneNumbers Array of phone numbers structured per API example
@@ -865,7 +863,6 @@ class TicketEvolution_Webservice
 
     /**
      * Create a client email address
-     * Currently the API only supports making one at a time
      *
      * @param  int $clientId ID of the specific client
      * @param  array $emailAddresses Array of email addresses structured per API example
@@ -1856,10 +1853,8 @@ class TicketEvolution_Webservice
     /**
      * Create an order
      *
-     * @param  array $orders Can be either an array with details for a single order
-                            or an array of arrays for multiple orders.
-                            Multiple items per order is not currently supported
-                            by the API.
+     * @param  array $orders Multiple items per order is not currently supported 
+     *      by the API.
      * @param bool $fulfillment Whether this is a fulfillment order or not
      * @throws TicketEvolution_Webservice_Exception
      * @return 


### PR DESCRIPTION
Aug 30, 2011 Part Deux
- Corrected some documentation. You can create multiple client addresses/emails/phone numbers in a single API call 
- Corrected demo app to show example of creating two client addresses at once
