### PR TITLE
- The parameters to list events by the primary performer has changed fro...

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 ## RELEASE INFORMATION
 
+### October 24, 2012 v1.9.13
+- The parameters to list events by the primary performer has changed from `primary_performer_id` to instead use `performer_id` and add the boolean `primary_performer`. Updated the Demo app to match.
+
 ### October 15, 2012 v1.9.12
 - Fixed bug (#83) with `createOrders()`
 

--- a/demo/index.php
+++ b/demo/index.php
@@ -1511,8 +1511,8 @@ if (isset($_REQUEST['apiMethod'])) {
                     </div>
 
                     <div class="listEvents">
-                        <label for="primary_performer_id">primary_performer_id:</label>
-                        <input name="primary_performer_id" id="primary_performer_id" type="text" value="" />
+                        <label for="primary_performer">primary_performer:</label>
+                        <input name="primary_performer" id="primary_performer" type="checkbox" value="true" />
                     </div>
 
                     <div class="listEvents">


### PR DESCRIPTION
...m `primary_performer_id` to instead use `performer_id` and add the boolean `primary_performer`. Updated the Demo app to match.
