### PR TITLE
Added the ability to time the API call & response using getElapsedTime()...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,18 @@
+## 2.1.2 (January 28, 2014)
+- Added the ability to time the API call & response using getElapsedTime(). This only times the actual call & response and does not include any of the setup time.
+
+## 2.1.1 (January 21, 2014)
+- Added searchEvents() for performing [full text search of events](https://ticketevolution.atlassian.net/wiki/pages/viewpage.action?pageId=9470096)
+- Added createOrdersFromJson() for [creating orders](https://ticketevolution.atlassian.net/wiki/pages/viewpage.action?pageId=9994275) from raw JSON
+- Removed @author attributions
+- Updated @copyright dates
+
 ## 2.1 (September 20, 2013)
 - Added some more specific Exception classes to make it easier to catch different types
 - Moved classes specific to the [DataLoader project](https://github.com/jwcobb/ticketevolution-php-dataloaders) to that project.
 - Cleaned up some inline documentation in `Webservice.php`
 - Reduced redundant code in most methods in `Webservice.php`
-- The copyright license has been transferred from [Team One Tickets & Sports Tours, Inc](http://www.teamonetickets.com) to [Ticket Evolution, Inc.](http://www.ticketevolution.com/). A copyright transfer agreement is on file with Ticket Evolution, Inc.
+- The copyright has been transferred from [Team One Tickets & Sports Tours, Inc](http://www.teamonetickets.com) to [Ticket Evolution, Inc.](http://www.ticketevolution.com/). A copyright transfer agreement is on file with Ticket Evolution, Inc.
 
 
 ## 2.0.6 (August 9, 2013)

--- a/library/TicketEvolution/Webservice.php
+++ b/library/TicketEvolution/Webservice.php
@@ -102,6 +102,22 @@ class Webservice
 
 
     /**
+     * Variable for measuring API call execution time.
+     *
+     * @var     float
+     */
+    protected $_timeStart;
+
+
+    /**
+     * Variable for measuring API call execution time.
+     *
+     * @var     float
+     */
+    protected $_timeEnd;
+
+
+    /**
      * Constructs a new Ticket Evolution Web Services Client
      *
      * @param   mixed   $config     An array or Zend_Config object with adapter parameters.
@@ -2111,7 +2127,10 @@ class Webservice
         );
 
         try {
-            return $client->restGet($this->_apiPrefix . $endPoint, $options);
+            $this->_startTimer();
+            $response = $client->restGet($this->_apiPrefix . $endPoint, $options);
+            $this->_endTimer();
+            return $response;
         } catch (\Exception $e) {
             throw new ApiConnectionException(
                 $e->getMessage(),
@@ -2154,7 +2173,10 @@ class Webservice
         );
 
         try {
-            return $client->restPost($this->_apiPrefix . $endPoint, $options);
+            $this->_startTimer();
+            $response = $client->restPost($this->_apiPrefix . $endPoint, $options);
+            $this->_endTimer();
+            return $response;
         } catch (\Exception $e) {
             throw new ApiConnectionException(
                 $e->getMessage(),
@@ -2197,7 +2219,10 @@ class Webservice
         );
 
         try {
-            return $client->restPut($this->_apiPrefix . $endPoint, $options);
+            $this->_startTimer();
+            $response = $client->restPut($this->_apiPrefix . $endPoint, $options);
+            $this->_endTimer();
+            return $response;
         } catch (\Exception $e) {
             throw new ApiConnectionException(
                 $e->getMessage(),
@@ -2345,6 +2370,40 @@ class Webservice
         }
 
         return $decodedJson;
+    }
+
+
+    /**
+     * Utility method for timing API calls.
+     *
+     */
+    protected function _startTimer()
+    {
+        $this->_timeStart = microtime(true);
+    }
+
+
+    /**
+     * Utility method for timing API calls.
+     *
+     */
+    protected function _endTimer()
+    {
+        $this->_timeEnd = microtime(true);
+    }
+
+
+    /**
+     * Utility method for timing API calls.
+     *
+     */
+    public function getElapsedTime()
+    {
+        try {
+            return $this->_timeEnd - $this->_timeStart;
+        } catch (\Exception $e) {
+            return false;
+        }
     }
 
 


### PR DESCRIPTION
....

This only times the actual call & response and does not include any of the setup time.
