### PR TITLE
- Update `bindShared()` to `singleton()` in `TEvoServiceProvider`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.4 (March 26, 2016)
+- Update `bindShared()` to `singleton()` in `TEvoServiceProvider` because `bindShared()` was deprecated in Laravel 5.1 and removed in Laravel 5.2.
+- Update installation instructions for Laravel.
+
 ## 3.0.3 (October 14, 2015)
 - Correct HTTP method for `cancelShipment`.
 - Correct `composer require` statements in some [Documentation](https://github.com/thephpleague/skeleton/blob/master/Documentation.md) examples.

--- a/Documentation.md
+++ b/Documentation.md
@@ -246,19 +246,19 @@ $ composer require ticketevolution/ticketevolution-php
 After updating composer add the `TEvoServiceProvider` to the `providers` array in `config/app.php`:
 
 ``` php
-'TicketEvolution\Laravel\TEvoServiceProvider',
+TicketEvolution\Laravel\TEvoServiceProvider::class,
 ```
 
 If you want to use the `TEvo` facade add this to the `aliases` array in `config/app.php`:
 
 ``` php
-'TEvo' => 'TicketEvolution\Laravel\TEvoFacade',
+'TEvo' => TicketEvolution\Laravel\TEvoFacade::class,
 ```
 
 To copy the default configuration file to `config/ticketevolution.php` run
 
 ``` bash
-$ php artisan vendor:publish
+$ php artisan vendor:publish --provider="TicketEvolution\Laravel\TEvoServiceProvider"
 ```
 
 In Laravel 5 it is recommended that you [keep your API credentials in your `.env` file](http://laravel.com/docs/5.0/configuration#environment-configuration) and that you do not publish that to your repo. In your `.env` you should include

--- a/src/Laravel/TEvoServiceProvider.php
+++ b/src/Laravel/TEvoServiceProvider.php
@@ -48,7 +48,7 @@ class TEvoServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->bindShared('tevo', function () {
+        $this->app->singleton('tevo', function () {
             return new Client(config('ticketevolution'));
         });
 


### PR DESCRIPTION
- Update `bindShared()` to `singleton()` in `TEvoServiceProvider` because `bindShared()` was deprecated in Laravel 5.1 and removed in Laravel 5.2.
- Update installation instructions for Laravel.