### PR TITLE
Update `listSearchSuggestions()` to use a comma-separated string for …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.0.5 (June 24, 2016)
+- Update `listSearchSuggestions()` to use a comma-separated string for the `entities` value instead of an array now that the corresponding endpoint allows that. This fixes #130.
+
 ## 3.0.4 (March 26, 2016)
 - Update `bindShared()` to `singleton()` in `TEvoServiceProvider` because `bindShared()` was deprecated in Laravel 5.1 and removed in Laravel 5.2.
 - Update installation instructions for Laravel.

--- a/src/Client.php
+++ b/src/Client.php
@@ -11,7 +11,7 @@ class Client
      *
      * @const string
      */
-    const VERSION = '3.0.4';
+    const VERSION = '3.0.5';
 
     /**
      * Guzzle service description

--- a/src/Resources/v9/search.php
+++ b/src/Resources/v9/search.php
@@ -72,16 +72,9 @@ return [
             'parameters'           => [
                 'entities'  => [
                     'location'    => 'query',
-                    'type'        => 'array',
-                    'description' => 'An array of entities for which you would like to get suggestions.',
-                    'required'    => false,
-                    'sentAs'      => 'entities',
-                ],
-                'entities2' => [
-                    'location'    => 'query',
                     'type'        => 'string',
-                    'description' => 'An array of entities for which you would like to get suggestions.',
-                    'required'    => false,
+                    'description' => 'A comma-separated list of entities for which you would like to get suggestions.',
+                    'required'    => true,
                     'sentAs'      => 'entities',
                 ],
                 'q'         => [


### PR DESCRIPTION
…the `entities` value instead of an array now that the corresponding endpoint allows that. This fixes #130.