### PR TITLE
Support slugs for some operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.0.7 (Aigust 17, 2016)
+- Allow strings to be used in addition to integers for `showPerformer()` and `showVenue()` so that the slugs may be used.
+
 ## 3.0.6 (Aigust 17, 2016)
 - Update `search()` to use a comma-separated string for the `types` value instead of an array now that the corresponding endpoint allows that.
 

--- a/src/Resources/v9/performers.php
+++ b/src/Resources/v9/performers.php
@@ -61,8 +61,8 @@ return [
             'parameters'           => [
                 'performer_id' => [
                     'location'    => 'uri',
-                    'type'        => 'integer',
-                    'description' => 'ID of the Performer to return.',
+                    'type'        => ['integer', 'string'],
+                    'description' => 'ID or slug of the Performer to return.',
                     'required'    => true,
                 ],
             ],

--- a/src/Resources/v9/venues.php
+++ b/src/Resources/v9/venues.php
@@ -61,8 +61,8 @@ return [
             'parameters'           => [
                 'venue_id' => [
                     'location'    => 'uri',
-                    'type'        => 'integer',
-                    'description' => 'ID of the Venue to return.',
+                    'type'        => ['integer', 'string'],
+                    'description' => 'ID or slug of the Venue to return.',
                     'required'    => true,
                 ],
             ],


### PR DESCRIPTION
Allow strings to be used in addition to integers for `showPerformer()` and `showVenue()` so that the slugs may be used.