### PR TITLE
Added `uploadAirbillForShipment()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.0.4 (June 19, 2017)
+- Added `uploadAirbillForShipment()` for uploading a base-64 encoded PDF airbill for a `ProvidedAirbill` shipment.
+- Correct documentation for adding a logger middleware under Advanced Usage.
+
 ## 4.0.3 (June 9, 2017)
 - Use `PUT` for `setTicketProperties()`.
 

--- a/Documentation.md
+++ b/Documentation.md
@@ -86,7 +86,7 @@ $apiClient = new TEvoClient([
     'apiVersion' => 'v9',
     'apiToken'   => 'xxxxxxxxxxxxxxxxxxxxxxxx',
     'apiSecret'  => 'yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy',
-]);
+], $middlewares);
 
 // Get a list of the 25 most popular events sorted by descending popularity
 try {

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client
      *
      * @const string
      */
-    const VERSION = '4.0.3';
+    const VERSION = '4.0.4';
 
     /**
      * Guzzle service description

--- a/src/Resources/v9/shipments.php
+++ b/src/Resources/v9/shipments.php
@@ -322,7 +322,7 @@ return [
 
 
         /**
-         *    Shipments / Download
+         *    Shipments / Download Airbill
          */
         'downloadAirbillForShipment' => [
             'extends'          => null,
@@ -339,6 +339,54 @@ return [
                     'type'        => 'integer',
                     'description' => 'The shipment number.',
                     'required'    => true,
+                ],
+            ],
+        ],
+
+
+        /**
+         *    Shipments / Upload Airbill
+         */
+        'uploadAirbillForShipment' => [
+            'extends'          => null,
+            'httpMethod'       => 'POST',
+            'uri'              => '/v9/shipments/{shipment_id}/upload_airbill',
+            'summary'          => 'Upload an airbill for the specified shipment.',
+            'notes'            => '',
+            'documentationUrl' => 'https://ticketevolution.atlassian.net/wiki/pages/viewpage.action?pageId=63602690',
+            'deprecated'       => false,
+            'responseModel'    => 'defaultJsonResponse',
+            'parameters'       => [
+                'shipment_id' => [
+                    'location'    => 'uri',
+                    'type'        => 'integer',
+                    'description' => 'The shipment number.',
+                    'required'    => true,
+                ],
+                'file' => [
+                    'location'    => 'json',
+                    'type'        => 'string',
+                    'description' => 'The base-64 encoded PDF.',
+                    'required'    => true,
+                ],
+                'tracking_number' => [
+                    'location'    => 'json',
+                    'type'        => 'string',
+                    'description' => 'The tracking number for the airbill being uploaded.',
+                    'required'    => true,
+                ],
+                'carrier' => [
+                    'location'    => 'json',
+                    'type'        => 'string',
+                    'description' => 'The carrier for which the airbill is provided.',
+                    'required'    => true,
+                    'enum'        => [
+                        'fedex',
+                        'ups',
+                        'usps',
+                        'dhl',
+                        'other',
+                    ],
                 ],
             ],
         ],


### PR DESCRIPTION
- Added `uploadAirbillForShipment()` for uploading a base-64 encoded PDF airbill for a `ProvidedAirbill` shipment.
- Correct documentation for adding a logger middleware under Advanced Usage.
