### PR TITLE
Fix a few minor issues as described in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.1.3 (March 29, 2019)
+- Correct location of `recipients` parameter for `emailAirbillForShipment()`.
+- Fix `rejection_notes` parameter for `rejectOrder()`.
+- Make `q` parameter optional for `searchEvents()`.
+
 ## 4.1.2 (February 11, 2019)
 - Ensure `include_tevo_section_mappings` is sent as a string when used with `listTicketGroups()`. (Thanks to @zimm0r)
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client
      *
      * @const string
      */
-    const VERSION = '4.1.2';
+    const VERSION = '4.1.3';
 
     /**
      * Guzzle service description

--- a/src/Resources/v9/events.php
+++ b/src/Resources/v9/events.php
@@ -119,7 +119,7 @@ return [
                     'location'    => 'query',
                     'type'        => 'string',
                     'description' => 'Full-text search events.',
-                    'required'    => true,
+                    'required'    => false,
                 ],
             ],
             'additionalParameters' => ['location' => 'query'],

--- a/src/Resources/v9/orders.php
+++ b/src/Resources/v9/orders.php
@@ -46,7 +46,7 @@ return [
                     'type'        => 'string',
                     'description' => 'The state of the order.',
                     'required'    => false,
-                    'enum' => [
+                    'enum'        => [
                         'accepted',
                         'cancel_proposed',
                         'canceled',
@@ -189,37 +189,37 @@ return [
             'deprecated'       => false,
             'responseModel'    => 'defaultJsonResponse',
             'parameters'       => [
-                'order_id'    => [
+                'order_id'        => [
                     'location'    => 'uri',
                     'type'        => 'integer',
                     'description' => 'The ID of the Order.',
                     'required'    => true,
                 ],
-                'reviewer_id' => [
+                'reviewer_id'     => [
                     'location'    => 'json',
                     'type'        => 'integer',
                     'description' => 'ID of the User who is accepting this Order.',
                     'required'    => true,
                 ],
-                'reason'      => [
-                    'location'        => 'json',
-                    'type'            => 'string',
-                    'description'     => 'The reason for which you are rejecting the order.',
-                    'required'        => true,
-                    'enum'            => [
+                'reason'          => [
+                    'location'    => 'json',
+                    'type'        => 'string',
+                    'description' => 'The reason for which you are rejecting the order.',
+                    'required'    => true,
+                    'enum'        => [
                         'Tickets No Longer Available',
                         'Tickets Priced Incorrectly',
                         'Duplicate Order',
                         'Fraudulent Order',
                         'Test Order',
                         'Other'
-                    ],
-                    'rejection_notes' => [
-                        'location'    => 'json',
-                        'type'        => 'string',
-                        'description' => 'Additional Notes about this rejection.',
-                        'required'    => false,
-                    ],
+                    ]
+                ],
+                'rejection_notes' => [
+                    'location'    => 'json',
+                    'type'        => 'string',
+                    'description' => 'Additional Notes about this rejection.',
+                    'required'    => false,
                 ],
             ],
         ],
@@ -782,5 +782,5 @@ return [
     |
     */
 
-    'models'     => [],
+    'models' => [],
 ];

--- a/src/Resources/v9/shipments.php
+++ b/src/Resources/v9/shipments.php
@@ -312,7 +312,7 @@ return [
                     'required'    => true,
                 ],
                 'recipients'  => [
-                    'location'    => 'uri',
+                    'location'    => 'json',
                     'type'        => 'array',
                     'description' => 'List of recipients that should receive the airbill.',
                     'required'    => true,


### PR DESCRIPTION
- Correct location of `recipients` parameter for `emailAirbillForShipment()`.
- Fix `rejection_notes` parameter for `rejectOrder()`.
- Make `q` parameter optional for `searchEvents()`.