### PR TITLE
Make `min_and_max_price` work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.2.2 (November 4, 2019)
+- Ensure that when `min_and_max_price` is used with `listEvents()` it is sent as a boolean-string because the comparison in the API requires `true` and not just a truthy value.
+
 ## 4.2.1 (April 22, 2019)
 - Added `deleteOfficeCreditCard()`.
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -16,7 +16,7 @@ class Client
      *
      * @const string
      */
-    const VERSION = '4.2.1';
+    const VERSION = '4.2.2';
 
     /**
      * Guzzle service description

--- a/src/Resources/v9/events.php
+++ b/src/Resources/v9/events.php
@@ -27,6 +27,14 @@ return [
             'deprecated'           => false,
             'responseModel'        => 'defaultJsonResponse',
             'parameters'           => [
+                'min_and_max_price' => [
+                    'location'    => 'query',
+                    'type'        => ['boolean', 'string'],
+                    'description' => 'If true the response will include avg_price, sum_price, median_price, min_price & max_price, calculated based on that Credential’s settings',
+                    'required'    => false,
+                    'default'     => false,
+                    'format'      => 'boolean-string',
+                ],
                 'page'     => [
                     'location'    => 'query',
                     'type'        => 'integer',


### PR DESCRIPTION
Ensure that when `min_and_max_price` is used with `listEvents()` it is sent as a boolean-string because the comparison in the API requires `true` and not just a truthy value.
