### PR TITLE
Allow symfony/config ^5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   ],
   "require": {
     "php": "^7.1.3",
-    "symfony/config": "^4.2",
+    "symfony/config": "^4.2|^5.0",
     "guzzlehttp/guzzle-services": "^1.1"
   },
   "suggest": {


### PR DESCRIPTION
- Allow usage of `symfony/config` ^5.0 in addition to ^4.2. Fixes the inability to install alongside newer versions of Laravel.