### PR TITLE
Allow `symfony/config` ^5.0 in addition to ^4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.2.3 (April 22, 2020)
+- Allow usage of `symfony/config` ^5.0 in addition to ^4.2. Fixes the inability to install alongside newer versions of Laravel.
+
 ## 4.2.2 (November 4, 2019)
 - Ensure that when `min_and_max_price` is used with `listEvents()` it is sent as a boolean-string because the comparison in the API requires `true` and not just a truthy value.
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   ],
   "require": {
     "php": "^7.1.3",
-    "symfony/config": "^4.2",
+    "symfony/config": "^4.2|^5.0",
     "guzzlehttp/guzzle-services": "^1.1"
   },
   "suggest": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -16,7 +16,7 @@ class Client
      *
      * @const string
      */
-    const VERSION = '4.2.2';
+    const VERSION = '4.2.3';
 
     /**
      * Guzzle service description


### PR DESCRIPTION
- Allow usage of `symfony/config` ^5.0 in addition to ^4.2. Fixes the inability to install alongside newer versions of Laravel.
