### PR TITLE
Change dependency config version condition from | to ||

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   ],
   "require": {
     "php": "^7.1.3",
-    "symfony/config": "^4.2|^5.0",
+    "symfony/config": "^4.2 || ^5.0",
     "guzzlehttp/guzzle-services": "^1.1"
   },
   "suggest": {


### PR DESCRIPTION
For fix problem with package installation on laravel 8.x changed

 `"symfony/config": "^4.2|^5.0"` to `"symfony/config": "^4.2 || ^5.0"`

this will solve that problem:

```
  Problem 1
    - Conclusion: don't install ticketevolution/ticketevolution-php 4.2.2
    - Conclusion: don't install ticketevolution/ticketevolution-php 4.2.1
    - Conclusion: remove cocur/slugify v4.0.0
    - Conclusion: don't install cocur/slugify v4.0.0
    - symfony/config 4.2.x-dev conflicts with cocur/slugify[v4.0.0].
    - symfony/config v4.2.0 conflicts with cocur/slugify[v4.0.0].
    - symfony/config v4.2.0-BETA1 conflicts with cocur/slugify[v4.0.0].
    - symfony/config v4.2.0-BETA2 conflicts with cocur/slugify[v4.0.0].
    - symfony/config v4.2.0-RC1 conflicts with cocur/slugify[v4.0.0].
    - symfony/config v4.2.1 conflicts with cocur/slugify[v4.0.0].
    - symfony/config v4.2.10 conflicts with cocur/slugify[v4.0.0].
    - symfony/config v4.2.11 conflicts with cocur/slugify[v4.0.0].
    - symfony/config v4.2.12 conflicts with cocur/slugify[v4.0.0].
    - symfony/config v4.2.2 conflicts with cocur/slugify[v4.0.0].
    - symfony/config v4.2.3 conflicts with cocur/slugify[v4.0.0].
    - symfony/config v4.2.4 conflicts with cocur/slugify[v4.0.0].
    - symfony/config v4.2.5 conflicts with cocur/slugify[v4.0.0].
    - symfony/config v4.2.6 conflicts with cocur/slugify[v4.0.0].
    - symfony/config v4.2.7 conflicts with cocur/slugify[v4.0.0].
    - symfony/config v4.2.8 conflicts with cocur/slugify[v4.0.0].
    - symfony/config v4.2.9 conflicts with cocur/slugify[v4.0.0].
    - Conclusion: don't install symfony/config v5.1.5|install symfony/config 4.2.x-dev|install symfony/config v4.2.0|install symfony/config v4.2.0-BETA1|install symfony/config v4.2.0-BETA2|install symfony/config v4.2.0-RC1|install symfony/config v4.2.1|install symfony/config v4.2.10|install symfony/config v4.2.11|install symfony/config v4.2.12|install symfony/config v4.2.2|install symfony/config v4.2.3|install symfony/config v4.2.4|install symfony/config v4.2.5|install symfony/config v4.2.6|install symfony/config v4.2.7|install symfony/config v4.2.8|install symfony/config v4.2.9
    - Conclusion: don't install ticketevolution/ticketevolution-php 4.2.2|remove symfony/config v5.1.5|install symfony/config 4.2.x-dev|install symfony/config v4.2.0|install symfony/config v4.2.0-BETA1|install symfony/config v4.2.0-BETA2|install symfony/config v4.2.0-RC1|install symfony/config v4.2.1|install symfony/config v4.2.10|install symfony/config v4.2.11|install symfony/config v4.2.12|install symfony/config v4.2.2|install symfony/config v4.2.3|install symfony/config v4.2.4|install symfony/config v4.2.5|install symfony/config v4.2.6|install symfony/config v4.2.7|install symfony/config v4.2.8|install symfony/config v4.2.9
    - Conclusion: don't install ticketevolution/ticketevolution-php 4.2.2|remove symfony/config v5.1.5|install symfony/config 4.2.x-dev|install symfony/config v4.2.0|install symfony/config v4.2.0-BETA1|install symfony/config v4.2.0-BETA2|install symfony/config v4.2.0-RC1|install symfony/config v4.2.1|install symfony/config v4.2.10|install symfony/config v4.2.11|install symfony/config v4.2.12|install symfony/config v4.2.2|install symfony/config v4.2.3|install symfony/config v4.2.4|install symfony/config v4.2.5|install symfony/config v4.2.6|install symfony/config v4.2.7|install symfony/config v4.2.8|install symfony/config v4.2.9
    - Conclusion: don't install ticketevolution/ticketevolution-php 4.2.1|remove symfony/config v5.1.5|install symfony/config 4.2.x-dev|install symfony/config v4.2.0|install symfony/config v4.2.0-BETA1|install symfony/config v4.2.0-BETA2|install symfony/config v4.2.0-RC1|install symfony/config v4.2.1|install symfony/config v4.2.10|install symfony/config v4.2.11|install symfony/config v4.2.12|install symfony/config v4.2.2|install symfony/config v4.2.3|install symfony/config v4.2.4|install symfony/config v4.2.5|install symfony/config v4.2.6|install symfony/config v4.2.7|install symfony/config v4.2.8|install symfony/config v4.2.9
    - Installation request for cocur/slugify (locked at v4.0.0) -> satisfiable by cocur/slugify[v4.0.0].
    - Conclusion: don't install ticketevolution/ticketevolution-php 4.2.1|remove symfony/config v5.1.5|install symfony/config 4.2.x-dev|install symfony/config v4.2.0|install symfony/config v4.2.0-BETA1|install symfony/config v4.2.0-BETA2|install symfony/config v4.2.0-RC1|install symfony/config v4.2.1|install symfony/config v4.2.10|install symfony/config v4.2.11|install symfony/config v4.2.12|install symfony/config v4.2.2|install symfony/config v4.2.3|install symfony/config v4.2.4|install symfony/config v4.2.5|install symfony/config v4.2.6|install symfony/config v4.2.7|install symfony/config v4.2.8|install symfony/config v4.2.9
    - Installation request for ticketevolution/ticketevolution-php ^4.2 -> satisfiable by ticketevolution/ticketevolution-php[4.2.0, 4.2.1, 4.2.2].
    - Conclusion: remove symfony/config v5.1.5|install symfony/config 4.2.x-dev|install symfony/config v4.2.0|install symfony/config v4.2.0-BETA1|install symfony/config v4.2.0-BETA2|install symfony/config v4.2.0-RC1|install symfony/config v4.2.1|install symfony/config v4.2.10|install symfony/config v4.2.11|install symfony/config v4.2.12|install symfony/config v4.2.2|install symfony/config v4.2.3|install symfony/config v4.2.4|install symfony/config v4.2.5|install symfony/config v4.2.6|install symfony/config v4.2.7|install symfony/config v4.2.8|install symfony/config v4.2.9
    - ticketevolution/ticketevolution-php 4.2.0 requires symfony/config ^4.2 -> satisfiable by symfony/config[4.2.x-dev, 4.3.x-dev, 4.4.x-dev, v4.2.0, v4.2.0-BETA1, v4.2.0-BETA2, v4.2.0-RC1, v4.2.1, v4.2.10, v4.2.11, v4.2.12, v4.2.2, v4.2.3, v4.2.4, v4.2.5, v4.2.6, v4.2.7, v4.2.8, v4.2.9, v4.3.0, v4.3.0-BETA1, v4.3.0-BETA2, v4.3.0-RC1, v4.3.1, v4.3.10, v4.3.11, v4.3.2, v4.3.3, v4.3.4, v4.3.5, v4.3.6, v4.3.7, v4.3.8, v4.3.9, v4.4.0, v4.4.0-BETA1, v4.4.0-BETA2, v4.4.0-RC1, v4.4.1, v4.4.10, v4.4.11, v4.4.12, v4.4.13, v4.4.2, v4.4.3, v4.4.4, v4.4.5, v4.4.6, v4.4.7, v4.4.8, v4.4.9].
    - Can only install one of: symfony/config[4.3.x-dev, v5.1.5].
    - Can only install one of: symfony/config[4.4.x-dev, v5.1.5].
    - Can only install one of: symfony/config[v4.3.0, v5.1.5].
    - Can only install one of: symfony/config[v4.3.0-BETA1, v5.1.5].
    - Can only install one of: symfony/config[v4.3.0-BETA2, v5.1.5].
    - Can only install one of: symfony/config[v4.3.0-RC1, v5.1.5].
    - Can only install one of: symfony/config[v4.3.1, v5.1.5].
    - Can only install one of: symfony/config[v4.3.10, v5.1.5].
    - Can only install one of: symfony/config[v4.3.11, v5.1.5].
    - Can only install one of: symfony/config[v4.3.2, v5.1.5].
    - Can only install one of: symfony/config[v4.3.3, v5.1.5].
    - Can only install one of: symfony/config[v4.3.4, v5.1.5].
    - Can only install one of: symfony/config[v4.3.5, v5.1.5].
    - Can only install one of: symfony/config[v4.3.6, v5.1.5].
    - Can only install one of: symfony/config[v4.3.7, v5.1.5].
    - Can only install one of: symfony/config[v4.3.8, v5.1.5].
    - Can only install one of: symfony/config[v4.3.9, v5.1.5].
    - Can only install one of: symfony/config[v4.4.0, v5.1.5].
    - Can only install one of: symfony/config[v4.4.0-BETA1, v5.1.5].
    - Can only install one of: symfony/config[v4.4.0-BETA2, v5.1.5].
    - Can only install one of: symfony/config[v4.4.0-RC1, v5.1.5].
    - Can only install one of: symfony/config[v4.4.1, v5.1.5].
    - Can only install one of: symfony/config[v4.4.10, v5.1.5].
    - Can only install one of: symfony/config[v4.4.11, v5.1.5].
    - Can only install one of: symfony/config[v4.4.12, v5.1.5].
    - Can only install one of: symfony/config[v4.4.13, v5.1.5].
    - Can only install one of: symfony/config[v4.4.2, v5.1.5].
    - Can only install one of: symfony/config[v4.4.3, v5.1.5].
    - Can only install one of: symfony/config[v4.4.4, v5.1.5].
    - Can only install one of: symfony/config[v4.4.5, v5.1.5].
    - Can only install one of: symfony/config[v4.4.6, v5.1.5].
    - Can only install one of: symfony/config[v4.4.7, v5.1.5].
    - Can only install one of: symfony/config[v4.4.8, v5.1.5].
    - Can only install one of: symfony/config[v4.4.9, v5.1.5].
    - Installation request for symfony/config (locked at v5.1.5) -> satisfiable by symfony/config[v5.1.5].
```