### PR TITLE
Add new `createTaxQuote()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.2.10 (December 16, 2021)
+- Add new `createTaxQuote()` method in preparation of the coming-soon [Tax Quotes / Create](https://ticketevolution.atlassian.net/wiki/spaces/API/pages/2900459521/Tax+Quotes) endpoint.
+
 ## 4.2.9 (December 8, 2021)
 - Add new `listings()` method to use the new faster and more efficient [Listings / Index](https://ticketevolution.atlassian.net/wiki/spaces/API/pages/2853797930/Listings+Index) endpoint.
 - Add new `showListing()` method to use the new faster and more efficient [Listings / Show](https://ticketevolution.atlassian.net/wiki/spaces/API/pages/2895052808/Listings+Show) endpoint.

--- a/src/Client.php
+++ b/src/Client.php
@@ -16,7 +16,7 @@ class Client
      *
      * @const string
      */
-    const VERSION = '4.2.9';
+    const VERSION = '4.2.10';
 
     /**
      * Guzzle service description

--- a/src/Resources/v9/service-description.php
+++ b/src/Resources/v9/service-description.php
@@ -68,6 +68,7 @@ return [
         'search.php',
         'settings.php',
         'shipments.php',
+        'tax.php',
         'ticket_groups.php',
         'tickets.php',
         'users.php',

--- a/src/Resources/v9/tax.php
+++ b/src/Resources/v9/tax.php
@@ -1,0 +1,66 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Operations
+    |--------------------------------------------------------------------------
+    |
+    | This array of operations is translated into methods that complete these
+    | requests based on their configuration.
+    |
+    */
+
+    'operations' => [
+
+        /**
+         *    Tax Quotes / Create
+         */
+        'createTaxQuote' => [
+            'extends'              => null,
+            'httpMethod'           => 'POST',
+            'uri'                  => '/v9/tax_quotes',
+            'summary'              => 'Create a tax quote.',
+            'notes'                => '',
+            'documentationUrl'     => 'https://ticketevolution.atlassian.net/wiki/spaces/API/pages/2898427919/WIP+Tax+Quotes+Create',
+            'deprecated'           => false,
+            'responseModel'        => 'defaultJsonResponse',
+            'parameters'           => [
+                'price'           => [
+                    'location'    => 'json',
+                    'type'        => 'numeric',
+                    'description' => 'The price the customer will be charged for each individual ticket.',
+                    'required'    => true,
+                ],
+                'quantity'        => [
+                    'location'    => 'json',
+                    'type'        => 'integer',
+                    'description' => 'The number of tickets the customer is purchasing.',
+                    'required'    => true,
+                ],
+                'ticket_group_id' => [
+                    'location'    => 'json',
+                    'type'        => 'integer',
+                    'description' => 'The ID of the ticket group from which the customer is purchasing.',
+                    'required'    => true,
+                ],
+            ],
+            'additionalParameters' => ['location' => 'json'],
+        ],
+
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Models
+    |--------------------------------------------------------------------------
+    |
+    | This array of models is specifications to returning the response
+    | from the operation methods.
+    |
+    */
+
+    'models' => [],
+];


### PR DESCRIPTION
- Add new `createTaxQuote()` method in preparation of the coming-soon [Tax Quotes / Create](https://ticketevolution.atlassian.net/wiki/spaces/API/pages/2900459521/Tax+Quotes) endpoint.
